### PR TITLE
add ssl policy settings

### DIFF
--- a/loadbalancer_private.tf
+++ b/loadbalancer_private.tf
@@ -227,6 +227,12 @@ resource "azurerm_application_gateway" "private" {
     }
   }
 
+  # SSL policy for the private application gateway
+  ssl_policy {
+    policy_type = var.ssl_policy_type
+    policy_name = var.ssl_policy_name
+  }
+
   tags = var.tags
 
   depends_on = [

--- a/loadbalancer_public.tf
+++ b/loadbalancer_public.tf
@@ -229,6 +229,12 @@ resource "azurerm_application_gateway" "public" {
     }
   }
 
+  # SSL policy for the public application gateway
+  ssl_policy {
+    policy_type = var.ssl_policy_type
+    policy_name = var.ssl_policy_name
+  }
+
   tags = var.tags
 
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -407,3 +407,15 @@ variable "private_endpoint_network_policies" {
   description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled. Defaults to Enabled to keep same value as before introducing this paramater"
   default     = "Enabled"
 }
+
+variable "ssl_policy_name" {
+  type        = string
+  description = "(Optional) The Name of the Policy e.g. AppGwSslPolicy20220101. Required if policy_type is set to Predefined. Possible values can change over time and are published here"
+  default     = "AppGwSslPolicy20220101"
+}
+
+variable "ssl_policy_type" {
+  type        = string
+  description = "(Optional) The Type of the Policy. Possible values are Predefined, Custom and CustomV2"
+  default     = "Predefined"
+}


### PR DESCRIPTION
**Azure retirement notice: Update Azure Application Gateway to TLS 1.2 or later before 31 August 2025** 

To align with security best practices, we'll require all connections to Application Gateway to be secured using Transport Layer Security (TLS) 1.2 or later beginning 31 August 2025, when support for TLS 1.0 and 1.1 will end.

**Required action**
To avoid service disruptions, you may need to take one or both of the following actions before 31 August 2025:

For frontend connections, [update your TLS policy](https://gbr01.safelinks.protection.outlook.com/?url=https%3A%2F%2Flearn.microsoft.com%2Fazure%2Fapplication-gateway%2Fapplication-gateway-ssl-policy-overview&data=05%7C02%7Cyhounsounou%40synamedia.com%7Ccb04c10f4d2749f4f11c08dd7d49e549%7Cecdd899a33be4c3391e41f1144fc2f56%7C0%7C0%7C638804478541629627%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=oYv0Pi8mvgKnPh%2BmIFAfJdYh2ARaxqrjaGdwMKS4Tjo%3D&reserved=0) to the predefined AppGwSslPolicy20220101S or AppGwSslPolicy20220101, or configure a custom policy with minimum TLS version 1.2. If you're using the CustomV2 policy, no action is required.
For backend connections, ensure your servers in the backend pools are compatible with TLS 1.2. This will prevent any issues with backend TLS/HTTPS connection.

**More information**

[Application-gateway-ssl-policy-overview](https://learn.microsoft.com/fr-fr/azure/application-gateway/application-gateway-ssl-policy-overview)

[Terraform Azurerm SSL Policy configuration ](https://registry.terraform.io/providers/hashicorp/Azurerm/latest/docs/resources/application_gateway#ssl_policy-2)
